### PR TITLE
fixed contrast bug and adjusted some colors

### DIFF
--- a/src/main/resources/themes.yml
+++ b/src/main/resources/themes.yml
@@ -510,21 +510,21 @@ other:
 
   - onelight:
     name: Atom One Light
-    name2: Atom One Light
+    name2: Atom One Light Contrast
     className: onelight
     desc: Theme based on the Atom One Light theme
     dark: false
     scheme: Atom One Light
-    background: '#F4F4F4'
+    background: '#FAFAFA'
     foreground: '#232324'
     text: '#7f7f7f'
-    selectBg: '#FFFFFF'
+    selectBg: '#2979ff80'
     selectFg: '#232324'
     selectFg2: '#232324'
     button: '#DBDBDC'
     second: '#EAEAEB'
     disabled: '#b8b8b9'
-    contrast: '#eaeae'
+    contrast: '#EAEAEA'
     table: '#DBDBDC'
     border: '#DBDBDC'
     hl: '#FFFFFF'

--- a/src/main/resources/themes/Atom One Light Contrast.theme.json
+++ b/src/main/resources/themes/Atom One Light Contrast.theme.json
@@ -1,12 +1,12 @@
 {
-  "name": "Atom One Light",
+  "name": "Atom One Light Contrast",
   "dark": false,
   "author": "Mallowigi",
   "editorScheme": "colors/Atom One Light.xml",
   "ui": {
     "*": {
       "acceleratorSelectionForeground": "#7f7f7f",
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "borderColor": "#DBDBDC",
       "disabledBackground": "#CACACB",
       "disabledForeground": "#b8b8b9",
@@ -17,13 +17,13 @@
       "inactiveBackground": "#CACACB",
       "inactiveForeground": "#7f7f7f",
       "infoForeground": "#7f7f7f",
-      "selectionBackground": "#FFFFFF",
+      "selectionBackground": "#2979ff80",
       "selectionBackgroundInactive": "#EAEAEB",
       "selectionForeground": "#232324",
       "selectionInactiveBackground": "#EAEAEB",
       "separatorColor": "#DBDBDC"
     },
-    "activeCaption": "#F4F4F4",
+    "activeCaption": "#FAFAFA",
     "ActionButton": {
       "hoverBackground": "#2979ff50",
       "hoverBorderColor": "#2979ff50",
@@ -33,13 +33,13 @@
       "pressedBorderColor": "#2979ff50"
     },
     "Autocomplete": {
-      "selectionBackground": "#FFFFFF"
+      "selectionBackground": "#2979ff80"
     },
-    "Borders.ContrastBorderColor": "#F4F4F4",
+    "Borders.ContrastBorderColor": "#FAFAFA",
     "Borders.color": "#DBDBDC",
     "Button": {
       "arc": 0,
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "default": {
         "endBackground": "#DBDBDC",
         "endBorderColor": "#DBDBDC",
@@ -73,11 +73,11 @@
       "Tooltip.background": "#F2F2F2"
     },
     "Content": {
-      "background": "#eaeae",
-      "selectionBackground": "#FFFFFF"
+      "background": "#EAEAEA",
+      "selectionBackground": "#2979ff80"
     },
     "CheckBox": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "disabledText": "#b8b8b9",
       "foreground": "#232324",
       "select": "#2979ff"
@@ -85,11 +85,11 @@
     "CheckBoxMenuItem": {
       "acceleratorForeground": "#7f7f7f",
       "acceleratorSelectionForeground": "#7f7f7f",
-      "background": "#F4F4F4",
-      "disabledBackground": "#F4F4F4",
+      "background": "#FAFAFA",
+      "disabledBackground": "#FAFAFA",
       "disabledForeground": "#b8b8b9",
       "foreground": "#232324",
-      "selectionBackground": "#FFFFFF",
+      "selectionBackground": "#2979ff80",
       "selectionForeground": "#232324"
     },
     "CodeWithMe": {
@@ -101,7 +101,7 @@
       }
     },
     "ColorChooser": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "foreground": "#232324",
       "swatchesDefaultRecentColor": "#232324"
     },
@@ -111,9 +111,9 @@
         "background": "#DBDBDC",
         "disabledIconColor": "#b8b8b9",
         "iconColor": "#232324",
-        "nonEditableBackground": "#F4F4F4"
+        "nonEditableBackground": "#FAFAFA"
       },
-      "background": "#eaeae",
+      "background": "#EAEAEA",
       "buttonBackground": "#DBDBDC",
       "darcula.hoveredArrowButtonForeground": "#2979ff",
       "disabledForeground": "#b8b8b9",
@@ -137,7 +137,7 @@
       "selectionGrayForeground": "#232324",
       "selectionInactiveInfoForeground": "#7f7f7f",
       "selectionInactiveBackground": "#FFFFFF",
-      "selectionBackground": "#FFFFFF",
+      "selectionBackground": "#2979ff80",
       "selectionForeground": "#232324",
       "selectionInfoForeground": "#232324"
     },
@@ -151,7 +151,7 @@
       "infoForeground": "#7f7f7f",
       "iconColor": "#232324"
     },
-    "control": "#F4F4F4",
+    "control": "#FAFAFA",
     "controlText": "#7f7f7f",
     "Counter": {
       "background": "#2979ff",
@@ -176,39 +176,39 @@
       "borderColor": "#FFFFFF"
     },
     "DefaultTabs": {
-      "background": "#F4F4F4",
-      "borderColor": "#F4F4F4",
+      "background": "#FAFAFA",
+      "borderColor": "#FAFAFA",
       "hoverBackground": "#DBDBDC",
-      "hoverColor": "#eaeae",
+      "hoverColor": "#EAEAEA",
       "hoverMaskColor": "#FFFFFF",
-      "inactiveColoredTabBackground": "#F4F4F4",
+      "inactiveColoredTabBackground": "#FAFAFA",
       "inactiveColoredFileBackground": "#DBDBDC",
       "inactiveUnderlineColor": "#2979ff",
-      "inactiveMaskColor": "#eaeae",
+      "inactiveMaskColor": "#EAEAEA",
       "underlineColor": "#2979ff",
       "underlinedTabBackground": "#DBDBDC",
       "underlinedTabForeground": "#232324"
     },
-    "Desktop.background": "#F4F4F4",
-    "DialogWrapper.southPanelBackground": "#F4F4F4",
-    "DialogWrapper.southPanelDivider": "#F4F4F4",
+    "Desktop.background": "#FAFAFA",
+    "DialogWrapper.southPanelBackground": "#FAFAFA",
+    "DialogWrapper.southPanelDivider": "#FAFAFA",
     "DragAndDrop": {
-      "areaBackground": "#F4F4F4",
-      "areaBorderColor": "#F4F4F4",
+      "areaBackground": "#FAFAFA",
+      "areaBorderColor": "#FAFAFA",
       "areaForeground": "#232324"
     },
     "Editor": {
-      "background": "#eaeae",
+      "background": "#EAEAEA",
       "foreground": "#232324",
       "shortcutForeground": "#7f7f7f"
     },
     "EditorPane": {
-      "background": "#eaeae",
+      "background": "#EAEAEA",
       "caretForeground": "#2979ff",
       "foreground": "#232324",
-      "inactiveBackground": "#F4F4F4",
+      "inactiveBackground": "#FAFAFA",
       "inactiveForeground": "#b8b8b9",
-      "selectionBackground": "#FFFFFF",
+      "selectionBackground": "#2979ff80",
       "selectionForeground": "#232324"
     },
     "EditorTabs": {
@@ -216,8 +216,8 @@
       "hoverBackground": "#FFFFFF",
       "hoverColor": "#FFFFFF",
       "hoverMaskColor": "#FFFFFF",
-      "inactiveMaskColor": "#F4F4F4",
-      "inactiveColoredFileBackground": "#F4F4F4",
+      "inactiveMaskColor": "#FAFAFA",
+      "inactiveColoredFileBackground": "#FAFAFA",
       "inactiveUnderlineColor": "#b8b8b9",
       "selectedForeground": "#232324",
       "selectedBackground": "#DBDBDC",
@@ -226,7 +226,7 @@
       "underlinedTabForeground": "#232324"
     },
     "EditorGroupsTabs": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "borderColor": "#EAEAEB",
       "hoverBackground": "#FFFFFF",
       "hoverColor": "#FFFFFF",
@@ -255,7 +255,7 @@
     },
     "Focus.color": "#DBDBDC",
     "FormattedTextField": {
-      "background": "#eaeae",
+      "background": "#EAEAEA",
       "caretForeground": "#2979ff",
       "foreground": "#232324",
       "inactiveBackground": "#DBDBDC",
@@ -270,14 +270,14 @@
     },
     "GutterTooltip": {
       "infoForeground": "#7f7f7f",
-      "lineSeparatorColor": "#F4F4F4"
+      "lineSeparatorColor": "#FAFAFA"
     },
     "HeaderColor": {
-      "active": "#F4F4F4",
-      "inactive": "#eaeae"
+      "active": "#FAFAFA",
+      "inactive": "#EAEAEA"
     },
     "HelpTooltip": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "borderColor": "#DBDBDC",
       "foreground": "#232324",
       "infoForeground": "#7f7f7f",
@@ -285,24 +285,24 @@
     },
     "Hyperlink.linkColor": "#2979ff",
     "inactiveCaption": "#EAEAEB",
-    "inactiveCaptionBorder": "#F4F4F4",
+    "inactiveCaptionBorder": "#FAFAFA",
     "inactiveCaptionText": "#7f7f7f",
     "info": "#7f7f7f",
     "infoText": "#7f7f7f",
     "IdeStatusBar.border": "4,4,4,4",
     "InformationHint.borderColor": "#DBDBDC",
     "InplaceRefactoringPopup": {
-      "borderColor": "#F4F4F4"
+      "borderColor": "#FAFAFA"
     },
     "InternalFrame": {
       "activeTitleForeground": "#232324",
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "inactiveTitleForeground": "#7f7f7f"
     },
     "Label": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "disabledForeground": "#b8b8b9",
-      "disabledShadow": "#F4F4F4",
+      "disabledShadow": "#FAFAFA",
       "disabledText": "#b8b8b9",
       "foreground": "#232324",
       "infoForeground": "#7f7f7f",
@@ -322,20 +322,20 @@
       "foreground": "#232324",
       "hoverBackground": "#DBDBDC80",
       "hoverInactiveBackground": "#DBDBDC",
-      "selectionBackground": "#FFFFFF",
+      "selectionBackground": "#2979ff80",
       "selectionForeground": "#232324",
       "selectionInactiveForeground": "#232324",
       "selectionInactiveBackground": "#DBDBDC80"
     },
     "material": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "branchColor": "#232324",
-      "contrast": "#eaeae",
+      "contrast": "#EAEAEA",
       "foreground": "#232324",
       "mergeCommits": "#DBDBDC",
       "primaryColor": "#7f7f7f",
       "selectionForeground": "#232324",
-      "tab.backgroundColor": "#F4F4F4",
+      "tab.backgroundColor": "#FAFAFA",
       "tab.borderColor": "#2979ff",
       "tagColor": "#7f7f7f"
     },
@@ -347,48 +347,48 @@
     "Menu": {
       "acceleratorForeground": "#7f7f7f",
       "acceleratorSelectionForeground": "#232324",
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "border": "4,2,4,2",
       "borderColor": "#EAEAEB",
       "disabledBackground": "#EAEAEB",
       "disabledForeground": "#b8b8b9",
       "foreground": "#232324",
-      "selectionBackground": "#FFFFFF",
+      "selectionBackground": "#2979ff80",
       "selectionForeground": "#232324",
       "separatorColor": "#DBDBDC"
     },
     "MenuBar": {
-      "background": "#eaeae",
-      "borderColor": "#F4F4F4",
-      "disabledBackground": "#F4F4F4",
+      "background": "#EAEAEA",
+      "borderColor": "#FAFAFA",
+      "disabledBackground": "#FAFAFA",
       "disabledForeground": "#b8b8b9",
       "foreground": "#232324",
-      "highlight": "#F4F4F4",
-      "selectionBackground": "#FFFFFF",
+      "highlight": "#FAFAFA",
+      "selectionBackground": "#2979ff80",
       "selectionForeground": "#232324",
-      "shadow": "#eaeae"
+      "shadow": "#EAEAEA"
     },
     "MenuItem": {
       "acceleratorForeground": "#7f7f7f",
       "acceleratorSelectionForeground": "#232324",
       "border": "4,2,4,2",
-      "background": "#F4F4F4",
-      "disabledBackground": "#F4F4F4",
+      "background": "#FAFAFA",
+      "disabledBackground": "#FAFAFA",
       "disabledForeground": "#b8b8b9",
       "foreground": "#232324",
-      "selectionBackground": "#FFFFFF",
+      "selectionBackground": "#2979ff80",
       "selectionForeground": "#232324"
     },
     "NavBar": {
       "arrowColor": "#232324",
-      "borderColor": "#F4F4F4"
+      "borderColor": "#FAFAFA"
     },
     "NewClass": {
       "Panel": {
-        "background": "#F4F4F4"
+        "background": "#FAFAFA"
       },
       "SearchField": {
-        "background": "#eaeae"
+        "background": "#EAEAEA"
       }
     },
     "NewPSD.warning": "#2979ff",
@@ -414,7 +414,7 @@
     },
     "OnePixelDivider.background": "#DBDBDC",
     "OptionPane": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "foreground": "#232324",
       "messageForeground": "#232324"
     },
@@ -424,7 +424,7 @@
       "disabledColor": "#b8b8b9"
     },
     "Panel": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "foreground": "#232324"
     },
     "ParameterInfo": {
@@ -438,7 +438,7 @@
       "lineSeparatorColor": "#DBDBDC"
     },
     "PasswordField": {
-      "background": "#eaeae",
+      "background": "#EAEAEA",
       "capsLockIconColor": "#2979ff",
       "caretForeground": "#2979ff",
       "foreground": "#232324",
@@ -447,13 +447,13 @@
       "selectionForeground": "#232324"
     },
     "Plugins": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "disabledForeground": "#b8b8b9",
       "eapTagBackground": "#FFFFFF",
       "hoverBackground": "#DBDBDC80",
       "lightSelectionBackground": "#DBDBDC",
       "paidTagBackground": "#FFFFFF",
-      "selectionBackground": "#FFFFFF",
+      "selectionBackground": "#2979ff80",
       "tagForeground": "#2979ff",
       "tagBackground": "#FFFFFF",
       "trialTagBackground": "#FFFFFF",
@@ -469,7 +469,7 @@
         "updateForeground": "#232324"
       },
       "SearchField": {
-        "background": "#eaeae",
+        "background": "#EAEAEA",
         "borderColor": "#DBDBDC"
       },
       "SectionHeader": {
@@ -484,36 +484,36 @@
     },
     "Popup": {
       "Advertiser": {
-        "background": "#F4F4F4",
-        "borderColor": "#F4F4F4",
+        "background": "#FAFAFA",
+        "borderColor": "#FAFAFA",
         "foreground": "#2979ff"
       },
-      "borderColor": "#eaeae",
-      "inactiveBorderColor": "#F4F4F4",
+      "borderColor": "#EAEAEA",
+      "inactiveBorderColor": "#FAFAFA",
       "innerBorderColor": "#EAEAEB",
       "Header": {
-        "activeBackground": "#F4F4F4",
-        "inactiveBackground": "#eaeae"
+        "activeBackground": "#FAFAFA",
+        "inactiveBackground": "#EAEAEA"
       },
       "paintBorder": true,
       "separatorForeground": "#232324",
       "separatorColor": "#EAEAEB",
       "Toolbar": {
-        "Floating.background": "#eaeae",
-        "background": "#eaeae",
-        "borderColor": "#eaeae"
+        "Floating.background": "#EAEAEA",
+        "background": "#EAEAEA",
+        "borderColor": "#EAEAEA"
       }
     },
     "PopupMenu": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "border": "2,0,2,0",
       "foreground": "#232324",
-      "translucentBackground": "#F4F4F4"
+      "translucentBackground": "#FAFAFA"
     },
     "PopupMenuSeparator.height": 10,
     "PopupMenuSeparator.stripeIndent": 5,
     "ProgressBar": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "foreground": "#2979ff",
       "indeterminateEndColor": "#2979ff",
       "indeterminateStartColor": "#2979ff",
@@ -525,70 +525,70 @@
       "referenceHighlightColor": "#2979ff"
     },
     "RadioButton": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "disabledText": "#b8b8b9",
       "foreground": "#232324"
     },
     "RadioButtonMenuItem": {
       "acceleratorForeground": "#7f7f7f",
       "acceleratorSelectionForeground": "#7f7f7f",
-      "background": "#F4F4F4",
-      "disabledBackground": "#F4F4F4",
+      "background": "#FAFAFA",
+      "disabledBackground": "#FAFAFA",
       "disabledForeground": "#b8b8b9",
       "foreground": "#232324",
-      "selectionBackground": "#FFFFFF",
+      "selectionBackground": "#2979ff80",
       "selectionForeground": "#232324"
     },
     "ScreenView.borderColor": "#DBDBDC",
     "ScrollBar": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "hoverThumbBorderColor": "#2979ff",
       "hoverThumbColor": "#2979ff",
-      "hoverTrackColor": "#F4F4F430",
+      "hoverTrackColor": "#FAFAFA30",
       "Mac": {
         "hoverThumbBorderColor": "#2979ff",
         "hoverThumbColor": "#2979ff",
-        "hoverTrackColor": "#F4F4F430",
+        "hoverTrackColor": "#FAFAFA30",
         "thumbBorderColor": "#2979ff70",
         "thumbColor": "#2979ff70",
-        "trackColor": "#F4F4F430",
+        "trackColor": "#FAFAFA30",
         "Transparent": {
           "hoverThumbBorderColor": "#2979ff",
           "hoverThumbColor": "#2979ff",
-          "hoverTrackColor": "#F4F4F430",
+          "hoverTrackColor": "#FAFAFA30",
           "thumbBorderColor": "#2979ff70",
           "thumbColor": "#2979ff70",
-          "trackColor": "#F4F4F430"
+          "trackColor": "#FAFAFA30"
         }
       },
       "thumb": "#FFFFFF",
       "thumbBorderColor": "#2979ff70",
       "thumbColor": "#2979ff70",
-      "trackColor": "#F4F4F430",
+      "trackColor": "#FAFAFA30",
       "Transparent": {
         "hoverThumbBorderColor": "#2979ff",
         "hoverThumbColor": "#2979ff",
-        "hoverTrackColor": "#F4F4F430",
+        "hoverTrackColor": "#FAFAFA30",
         "thumbBorderColor": "#2979ff70",
         "thumbColor": "#2979ff70",
-        "trackColor": "#F4F4F430"
+        "trackColor": "#FAFAFA30"
       }
     },
     "SearchEverywhere": {
       "Advertiser": {
-        "background": "#eaeae",
+        "background": "#EAEAEA",
         "foreground": "#7f7f7f"
       },
       "Header": {
-        "background": "#F4F4F4"
+        "background": "#FAFAFA"
       },
       "List": {
         "separatorForeground": "#7f7f7f",
         "separatorColor": "#DBDBDC"
       },
       "SearchField": {
-        "background": "#F4F4F4",
-        "borderColor": "#eaeae",
+        "background": "#FAFAFA",
+        "borderColor": "#EAEAEA",
         "infoForeground": "#7f7f7f"
       },
       "Tab": {
@@ -617,10 +617,10 @@
       "separatorColor": "#EAEAEB"
     },
     "SidePanel": {
-      "background": "#eaeae"
+      "background": "#EAEAEA"
     },
     "Slider": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "buttonBorderColor": "#2979ff",
       "buttonColor": "#2979ff",
       "foreground": "#232324",
@@ -637,23 +637,23 @@
       "errorForeground": "#232324"
     },
     "Spinner": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "border": "3,3,3,3",
       "foreground": "#232324",
       "selectionForeground": "#232324"
     },
     "SplitPane": {
-      "background": "#F4F4F4",
-      "highlight": "#eaeae"
+      "background": "#FAFAFA",
+      "highlight": "#EAEAEA"
     },
     "SplitPaneDivider.draggingColor": "#EAEAEB",
     "StatusBar": {
-      "borderColor": "#F4F4F4",
+      "borderColor": "#FAFAFA",
       "hoverBackground": "#FFFFFF",
       "LightEditBackground": "#DBDBDC"
     },
     "TabbedPane": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "contentAreaColor": "#FFFFFF",
       "contentBorderInsets": "3,1,1,1",
       "darkShadow": "#DBDBDC",
@@ -675,10 +675,10 @@
       "tabSelectionHeight": 2,
       "underlineColor": "#2979ff"
     },
-    "TabbedPane.mt.tab.background": "#eaeae",
+    "TabbedPane.mt.tab.background": "#EAEAEA",
     "Table": {
-      "alternativeRowBackground": "#eaeae",
-      "background": "#F4F4F4",
+      "alternativeRowBackground": "#EAEAEA",
+      "background": "#FAFAFA",
       "cellNoFocusBorder": "10,5,10,5",
       "focusCellHighlightBorder": "10,5,10,5",
       "disabledForeground": "#b8b8b9",
@@ -687,7 +687,7 @@
       "focusCellBackground": "#DBDBDC",
       "focusCellForeground": "#232324",
       "foreground": "#232324",
-      "gridColor": "#F4F4F4",
+      "gridColor": "#FAFAFA",
       "highlightOuter": "#DBDBDC",
       "hoverBackground": "#DBDBDC80",
       "hoverInactiveBackground": "#DBDBDC",
@@ -699,11 +699,11 @@
       "selectionInactiveBackground": "#DBDBDC",
       "selectionInactiveForeground": "#232324",
       "sortIconColor": "#232324",
-      "stripeColor": "#eaeae"
+      "stripeColor": "#EAEAEA"
     },
     "TableHeader": {
-      "background": "#F4F4F4",
-      "borderColor": "#F4F4F4",
+      "background": "#FAFAFA",
+      "borderColor": "#FAFAFA",
       "bottomSeparatorColor": "#EAEAEB",
       "cellBorder": "4,0,4,0",
       "disabledForeground": "#b8b8b9",
@@ -717,7 +717,7 @@
     "textInactiveText": "#7f7f7f",
     "textText": "#7f7f7f",
     "TextArea": {
-      "background": "#eaeae",
+      "background": "#EAEAEA",
       "caretForeground": "#2979ff",
       "foreground": "#232324",
       "inactiveForeground": "#b8b8b9",
@@ -725,7 +725,7 @@
       "selectionForeground": "#232324"
     },
     "TextField": {
-      "background": "#eaeae",
+      "background": "#EAEAEA",
       "caretForeground": "#2979ff",
       "foreground": "#232324",
       "inactiveForeground": "#b8b8b9",
@@ -733,7 +733,7 @@
       "selectionForeground": "#232324"
     },
     "TextPane": {
-      "background": "#eaeae",
+      "background": "#EAEAEA",
       "caretForeground": "#2979ff",
       "foreground": "#232324",
       "inactiveForeground": "#b8b8b9",
@@ -741,9 +741,9 @@
       "selectionForeground": "#232324"
     },
     "TitlePane": {
-      "background": "#eaeae",
+      "background": "#EAEAEA",
       "Button.hoverBackground": "#FFFFFF",
-      "inactiveBackground": "#F4F4F4",
+      "inactiveBackground": "#FAFAFA",
       "infoForeground": "#7f7f7f",
       "inactiveInfoForeground": "#7f7f7f"
     },
@@ -753,19 +753,19 @@
       "buttonColor": "#232324",
       "disabledText": "#b8b8b9",
       "foreground": "#232324",
-      "offForeground": "#F4F4F4",
-      "offBackground": "#F4F4F4",
+      "offForeground": "#FAFAFA",
+      "offBackground": "#FAFAFA",
       "onBackground": "#2979ff",
       "onForeground": "#2979ff"
     },
     "ToolBar": {
-      "background": "#eaeae",
+      "background": "#EAEAEA",
       "borderHandleColor": "#7f7f7f",
       "floatingForeground": "#7f7f7f",
       "foreground": "#232324"
     },
     "ToolTip": {
-      "Actions.background": "#F4F4F4",
+      "Actions.background": "#FAFAFA",
       "Actions.infoForeground": "#7f7f7f",
       "background": "#F2F2F2",
       "borderColor": "#DBDBDC",
@@ -778,23 +778,23 @@
       "Button": {
         "hoverBackground": "#DBDBDC",
         "selectedForeground": "#232324",
-        "selectedBackground": "#eaeae"
+        "selectedBackground": "#EAEAEA"
       },
       "Header": {
-        "background": "#F4F4F4",
+        "background": "#FAFAFA",
         "borderColor": "#EAEAEB",
-        "inactiveBackground": "#F4F4F4"
+        "inactiveBackground": "#FAFAFA"
       },
       "HeaderCloseButton": {
-        "background": "#F4F4F4"
+        "background": "#FAFAFA"
       },
       "HeaderTab": {
         "borderColor": "#FFFFFF",
         "hoverBackground": "#FFFFFF",
         "hoverInactiveBackground": "#FFFFFF",
         "inactiveUnderlineColor": "#2979ff",
-        "selectedBackground": "#eaeae",
-        "selectedInactiveBackground": "#eaeae",
+        "selectedBackground": "#EAEAEA",
+        "selectedInactiveBackground": "#EAEAEA",
         "underlineColor": "#2979ff",
         "underlinedTabBackground": "#DBDBDC",
         "underlinedTabInactiveBackground": "#EAEAEB",
@@ -803,7 +803,7 @@
       }
     },
     "Tree": {
-      "background": "#eaeae",
+      "background": "#EAEAEA",
       "foreground": "#7f7f7f",
       "hash": "#DBDBDC",
       "hoverBackground": "#DBDBDC80",
@@ -814,20 +814,20 @@
       "selectionForeground": "#232324",
       "selectionInactiveForeground": "#232324",
       "selectionInactiveBackground": "#DBDBDC80",
-      "textBackground": "#eaeae"
+      "textBackground": "#EAEAEA"
     },
     "Tree.leftChildIndent": 10,
     "Tree.rightChildIndent": 5,
     "UIDesigner": {
       "Activity.borderColor": "#DBDBDC",
-      "Canvas.background": "#eaeae",
+      "Canvas.background": "#EAEAEA",
       "ColorPicker": {
-        "background": "#F4F4F4",
+        "background": "#FAFAFA",
         "foreground": "#232324"
       },
       "Component": {
         "borderColor": "#DBDBDC",
-        "background": "#F4F4F4",
+        "background": "#FAFAFA",
         "foreground": "#232324",
         "hoverBorderColor": "#FFFFFF"
       },
@@ -835,7 +835,7 @@
         "borderColor": "#DBDBDC",
         "hoverBorderColor": "#FFFFFF"
       },
-      "Canvas.background": "#eaeae",
+      "Canvas.background": "#EAEAEA",
       "highStroke.foreground": "#232324",
       "Label.foreground": "#7f7f7f",
       "List.selectionBackground": "#DBDBDC80",
@@ -844,12 +844,12 @@
         "Component.foreground": "#232324",
         "ConstraintSetText.foreground": "#7f7f7f",
         "ConstraintSet.background": "#EAEAEB",
-        "CSPanel.SelectedFocusBackground": "#FFFFFF",
+        "CSPanel.SelectedFocusBackground": "#2979ff80",
         "CSPanel.SelectedBackground": "#DBDBDC80",
         "cs_FocusText.infoForeground": "#7f7f7f",
         "CursorTextColor.foreground": "#232324",
         "HoverColor.disabledBackground": "#b8b8b9",
-        "motionGraph.background": "#F4F4F4",
+        "motionGraph.background": "#FAFAFA",
         "Notification.background": "#F2F2F2",
         "ourAvg.background": "#EAEAEB",
         "ourCS.background": "#EAEAEB",
@@ -859,24 +859,24 @@
         "ourCS_SelectedBackground.selectionInactiveBackground": "#DBDBDC",
         "ourCS_SelectedBorder.pressedBorderColor": "#FFFFFF",
         "ourML_BarColor.separatorColor": "#DBDBDC",
-        "PrimaryPanel.background": "#eaeae",
-        "SecondaryPanel.background": "#F4F4F4",
+        "PrimaryPanel.background": "#EAEAEA",
+        "SecondaryPanel.background": "#FAFAFA",
         "SecondaryPanel.header.foreground": "#7f7f7f",
-        "SecondaryPanel.header.background": "#eaeae",
+        "SecondaryPanel.header.background": "#EAEAEA",
         "timeLine.disabledBorderColor": "#DBDBDC"
       },
       "Panel": {
         "borderColor": "#DBDBDC",
-        "background": "#F4F4F4"
+        "background": "#FAFAFA"
       },
       "percent.foreground": "#232324",
       "Placeholder": {
-        "background": "#F4F4F4",
+        "background": "#FAFAFA",
         "borderColor": "#DBDBDC",
         "foreground": "#232324",
         "selectedForeground": "#232324"
       },
-      "Preview.background": "#F4F4F4",
+      "Preview.background": "#FAFAFA",
       "stroke.acceleratorForeground": "#7f7f7f"
     },
     "ValidationTooltip": {
@@ -887,7 +887,7 @@
     },
     "VersionControl": {
       "FileHistory.Commit": {
-        "selectedBranchBackground": "#F4F4F4"
+        "selectedBranchBackground": "#FAFAFA"
       },
       "GitCommits": {
         "graphColor": "#FFFFFF"
@@ -918,44 +918,44 @@
       }
     },
     "Viewport": {
-      "background": "#eaeae",
+      "background": "#EAEAEA",
       "foreground": "#232324"
     },
     "WelcomeScreen": {
-      "AssociatedComponent.background": "#F4F4F4",
-      "background": "#F4F4F4",
-      "borderColor": "#F4F4F4",
-      "captionBackground": "#eaeae",
+      "AssociatedComponent.background": "#FAFAFA",
+      "background": "#FAFAFA",
+      "borderColor": "#FAFAFA",
+      "captionBackground": "#EAEAEA",
       "captionForeground": "#232324",
-      "Details.background": "#F4F4F4",
-      "footerBackground": "#eaeae",
+      "Details.background": "#FAFAFA",
+      "footerBackground": "#EAEAEA",
       "footerForeground": "#232324",
-      "headerBackground": "#F4F4F4",
+      "headerBackground": "#FAFAFA",
       "headerForeground": "#232324",
-      "List.background": "#eaeae",
+      "List.background": "#EAEAEA",
       "separatorColor": "#DBDBDC",
       "SidePanel.background": "#EAEAEB",
       "Projects": {
-        "actions.background": "#eaeae",
+        "actions.background": "#EAEAEA",
         "actions.selectionBackground": "#FFFFFF",
         "background": "#EAEAEB",
-        "selectionBackground": "#FFFFFF",
+        "selectionBackground": "#2979ff80",
         "selectionInactiveBackground": "#EAEAEB"
       }
     },
-    "window": "#eaeae",
+    "window": "#EAEAEA",
     "windowBorder": "#DBDBDC",
     "windowText": "#7f7f7f",
     "Window.border": "#DBDBDC"
   },
   "icons": {
     "ColorPalette": {
-      "#43494A": "#eaeae",
+      "#43494A": "#EAEAEA",
       "#6B6B6B": "#7f7f7f",
-      "#A7A7A7": "#F4F4F4",
+      "#A7A7A7": "#FAFAFA",
       "#3D6185": "#2979ff",
       "#466D94": "#2979ff",
-      "#3C3F41": "#F4F4F4",
+      "#3C3F41": "#FAFAFA",
       "#545556": "#b8b8b9",
       "#606060": "#b8b8b9",
       "#9AA7B0": "#232324",
@@ -967,8 +967,8 @@
       "Actions.GreyInline.Dark": "#232324",
       "Actions.Red": "#E4564A",
       "Actions.Yellow": "#C18401",
-      "Checkbox.Background.Default": "#eaeae",
-      "Checkbox.Background.Default.Dark": "#eaeae",
+      "Checkbox.Background.Default": "#EAEAEA",
+      "Checkbox.Background.Default.Dark": "#EAEAEA",
       "Checkbox.Background.Disabled": "#CACACB",
       "Checkbox.Background.Disabled.Dark": "#CACACB",
       "Checkbox.Border.Default": "#DBDBDC",
@@ -982,7 +982,7 @@
       "Checkbox.Foreground.Disabled": "#b8b8b9",
       "Checkbox.Foreground.Disabled.Dark": "#b8b8b9",
       "Checkbox.Background.Selected": "#2979ff",
-      "Checkbox.Background.Selected.Dark": "#F4F4F4",
+      "Checkbox.Background.Selected.Dark": "#FAFAFA",
       "Checkbox.Border.Selected": "#2979ff",
       "Checkbox.Border.Selected.Dark": "#2979ff",
       "Checkbox.Foreground.Selected": "#2979ff",

--- a/src/main/resources/themes/Atom One Light.theme.json
+++ b/src/main/resources/themes/Atom One Light.theme.json
@@ -6,7 +6,7 @@
   "ui": {
     "*": {
       "acceleratorSelectionForeground": "#7f7f7f",
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "borderColor": "#DBDBDC",
       "disabledBackground": "#CACACB",
       "disabledForeground": "#b8b8b9",
@@ -17,13 +17,13 @@
       "inactiveBackground": "#CACACB",
       "inactiveForeground": "#7f7f7f",
       "infoForeground": "#7f7f7f",
-      "selectionBackground": "#FFFFFF",
+      "selectionBackground": "#2979ff80",
       "selectionBackgroundInactive": "#EAEAEB",
       "selectionForeground": "#232324",
       "selectionInactiveBackground": "#EAEAEB",
       "separatorColor": "#DBDBDC"
     },
-    "activeCaption": "#F4F4F4",
+    "activeCaption": "#FAFAFA",
     "ActionButton": {
       "hoverBackground": "#2979ff50",
       "hoverBorderColor": "#2979ff50",
@@ -33,13 +33,13 @@
       "pressedBorderColor": "#2979ff50"
     },
     "Autocomplete": {
-      "selectionBackground": "#FFFFFF"
+      "selectionBackground": "#2979ff80"
     },
-    "Borders.ContrastBorderColor": "#F4F4F4",
+    "Borders.ContrastBorderColor": "#FAFAFA",
     "Borders.color": "#DBDBDC",
     "Button": {
       "arc": 0,
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "default": {
         "endBackground": "#DBDBDC",
         "endBorderColor": "#DBDBDC",
@@ -73,11 +73,11 @@
       "Tooltip.background": "#F2F2F2"
     },
     "Content": {
-      "background": "#eaeae",
-      "selectionBackground": "#FFFFFF"
+      "background": "#EAEAEA",
+      "selectionBackground": "#2979ff80"
     },
     "CheckBox": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "disabledText": "#b8b8b9",
       "foreground": "#232324",
       "select": "#2979ff"
@@ -85,11 +85,11 @@
     "CheckBoxMenuItem": {
       "acceleratorForeground": "#7f7f7f",
       "acceleratorSelectionForeground": "#7f7f7f",
-      "background": "#F4F4F4",
-      "disabledBackground": "#F4F4F4",
+      "background": "#FAFAFA",
+      "disabledBackground": "#FAFAFA",
       "disabledForeground": "#b8b8b9",
       "foreground": "#232324",
-      "selectionBackground": "#FFFFFF",
+      "selectionBackground": "#2979ff80",
       "selectionForeground": "#232324"
     },
     "CodeWithMe": {
@@ -101,7 +101,7 @@
       }
     },
     "ColorChooser": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "foreground": "#232324",
       "swatchesDefaultRecentColor": "#232324"
     },
@@ -111,9 +111,9 @@
         "background": "#DBDBDC",
         "disabledIconColor": "#b8b8b9",
         "iconColor": "#232324",
-        "nonEditableBackground": "#F4F4F4"
+        "nonEditableBackground": "#FAFAFA"
       },
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "buttonBackground": "#DBDBDC",
       "darcula.hoveredArrowButtonForeground": "#2979ff",
       "disabledForeground": "#b8b8b9",
@@ -137,7 +137,7 @@
       "selectionGrayForeground": "#232324",
       "selectionInactiveInfoForeground": "#7f7f7f",
       "selectionInactiveBackground": "#FFFFFF",
-      "selectionBackground": "#FFFFFF",
+      "selectionBackground": "#2979ff80",
       "selectionForeground": "#232324",
       "selectionInfoForeground": "#232324"
     },
@@ -151,7 +151,7 @@
       "infoForeground": "#7f7f7f",
       "iconColor": "#232324"
     },
-    "control": "#F4F4F4",
+    "control": "#FAFAFA",
     "controlText": "#7f7f7f",
     "Counter": {
       "background": "#2979ff",
@@ -176,39 +176,39 @@
       "borderColor": "#FFFFFF"
     },
     "DefaultTabs": {
-      "background": "#F4F4F4",
-      "borderColor": "#F4F4F4",
+      "background": "#FAFAFA",
+      "borderColor": "#FAFAFA",
       "hoverBackground": "#DBDBDC",
-      "hoverColor": "#F4F4F4",
+      "hoverColor": "#FAFAFA",
       "hoverMaskColor": "#FFFFFF",
-      "inactiveColoredTabBackground": "#F4F4F4",
+      "inactiveColoredTabBackground": "#FAFAFA",
       "inactiveColoredFileBackground": "#DBDBDC",
       "inactiveUnderlineColor": "#2979ff",
-      "inactiveMaskColor": "#F4F4F4",
+      "inactiveMaskColor": "#FAFAFA",
       "underlineColor": "#2979ff",
       "underlinedTabBackground": "#DBDBDC",
       "underlinedTabForeground": "#232324"
     },
-    "Desktop.background": "#F4F4F4",
-    "DialogWrapper.southPanelBackground": "#F4F4F4",
-    "DialogWrapper.southPanelDivider": "#F4F4F4",
+    "Desktop.background": "#FAFAFA",
+    "DialogWrapper.southPanelBackground": "#FAFAFA",
+    "DialogWrapper.southPanelDivider": "#FAFAFA",
     "DragAndDrop": {
-      "areaBackground": "#F4F4F4",
-      "areaBorderColor": "#F4F4F4",
+      "areaBackground": "#FAFAFA",
+      "areaBorderColor": "#FAFAFA",
       "areaForeground": "#232324"
     },
     "Editor": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "foreground": "#232324",
       "shortcutForeground": "#7f7f7f"
     },
     "EditorPane": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "caretForeground": "#2979ff",
       "foreground": "#232324",
-      "inactiveBackground": "#F4F4F4",
+      "inactiveBackground": "#FAFAFA",
       "inactiveForeground": "#b8b8b9",
-      "selectionBackground": "#FFFFFF",
+      "selectionBackground": "#2979ff80",
       "selectionForeground": "#232324"
     },
     "EditorTabs": {
@@ -216,8 +216,8 @@
       "hoverBackground": "#FFFFFF",
       "hoverColor": "#FFFFFF",
       "hoverMaskColor": "#FFFFFF",
-      "inactiveMaskColor": "#F4F4F4",
-      "inactiveColoredFileBackground": "#F4F4F4",
+      "inactiveMaskColor": "#FAFAFA",
+      "inactiveColoredFileBackground": "#FAFAFA",
       "inactiveUnderlineColor": "#b8b8b9",
       "selectedForeground": "#232324",
       "selectedBackground": "#DBDBDC",
@@ -226,7 +226,7 @@
       "underlinedTabForeground": "#232324"
     },
     "EditorGroupsTabs": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "borderColor": "#EAEAEB",
       "hoverBackground": "#FFFFFF",
       "hoverColor": "#FFFFFF",
@@ -255,7 +255,7 @@
     },
     "Focus.color": "#DBDBDC",
     "FormattedTextField": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "caretForeground": "#2979ff",
       "foreground": "#232324",
       "inactiveBackground": "#DBDBDC",
@@ -270,14 +270,14 @@
     },
     "GutterTooltip": {
       "infoForeground": "#7f7f7f",
-      "lineSeparatorColor": "#F4F4F4"
+      "lineSeparatorColor": "#FAFAFA"
     },
     "HeaderColor": {
-      "active": "#F4F4F4",
-      "inactive": "#eaeae"
+      "active": "#FAFAFA",
+      "inactive": "#EAEAEA"
     },
     "HelpTooltip": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "borderColor": "#DBDBDC",
       "foreground": "#232324",
       "infoForeground": "#7f7f7f",
@@ -285,24 +285,24 @@
     },
     "Hyperlink.linkColor": "#2979ff",
     "inactiveCaption": "#EAEAEB",
-    "inactiveCaptionBorder": "#F4F4F4",
+    "inactiveCaptionBorder": "#FAFAFA",
     "inactiveCaptionText": "#7f7f7f",
     "info": "#7f7f7f",
     "infoText": "#7f7f7f",
     "IdeStatusBar.border": "4,4,4,4",
     "InformationHint.borderColor": "#DBDBDC",
     "InplaceRefactoringPopup": {
-      "borderColor": "#F4F4F4"
+      "borderColor": "#FAFAFA"
     },
     "InternalFrame": {
       "activeTitleForeground": "#232324",
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "inactiveTitleForeground": "#7f7f7f"
     },
     "Label": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "disabledForeground": "#b8b8b9",
-      "disabledShadow": "#F4F4F4",
+      "disabledShadow": "#FAFAFA",
       "disabledText": "#b8b8b9",
       "foreground": "#232324",
       "infoForeground": "#7f7f7f",
@@ -322,20 +322,20 @@
       "foreground": "#232324",
       "hoverBackground": "#DBDBDC80",
       "hoverInactiveBackground": "#DBDBDC",
-      "selectionBackground": "#FFFFFF",
+      "selectionBackground": "#2979ff80",
       "selectionForeground": "#232324",
       "selectionInactiveForeground": "#232324",
       "selectionInactiveBackground": "#DBDBDC80"
     },
     "material": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "branchColor": "#232324",
-      "contrast": "#eaeae",
+      "contrast": "#EAEAEA",
       "foreground": "#232324",
       "mergeCommits": "#DBDBDC",
       "primaryColor": "#7f7f7f",
       "selectionForeground": "#232324",
-      "tab.backgroundColor": "#F4F4F4",
+      "tab.backgroundColor": "#FAFAFA",
       "tab.borderColor": "#2979ff",
       "tagColor": "#7f7f7f"
     },
@@ -347,48 +347,48 @@
     "Menu": {
       "acceleratorForeground": "#7f7f7f",
       "acceleratorSelectionForeground": "#232324",
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "border": "4,2,4,2",
       "borderColor": "#EAEAEB",
       "disabledBackground": "#EAEAEB",
       "disabledForeground": "#b8b8b9",
       "foreground": "#232324",
-      "selectionBackground": "#FFFFFF",
+      "selectionBackground": "#2979ff80",
       "selectionForeground": "#232324",
       "separatorColor": "#DBDBDC"
     },
     "MenuBar": {
-      "background": "#F4F4F4",
-      "borderColor": "#F4F4F4",
-      "disabledBackground": "#F4F4F4",
+      "background": "#FAFAFA",
+      "borderColor": "#FAFAFA",
+      "disabledBackground": "#FAFAFA",
       "disabledForeground": "#b8b8b9",
       "foreground": "#232324",
-      "highlight": "#F4F4F4",
-      "selectionBackground": "#FFFFFF",
+      "highlight": "#FAFAFA",
+      "selectionBackground": "#2979ff80",
       "selectionForeground": "#232324",
-      "shadow": "#F4F4F4"
+      "shadow": "#FAFAFA"
     },
     "MenuItem": {
       "acceleratorForeground": "#7f7f7f",
       "acceleratorSelectionForeground": "#232324",
       "border": "4,2,4,2",
-      "background": "#F4F4F4",
-      "disabledBackground": "#F4F4F4",
+      "background": "#FAFAFA",
+      "disabledBackground": "#FAFAFA",
       "disabledForeground": "#b8b8b9",
       "foreground": "#232324",
-      "selectionBackground": "#FFFFFF",
+      "selectionBackground": "#2979ff80",
       "selectionForeground": "#232324"
     },
     "NavBar": {
       "arrowColor": "#232324",
-      "borderColor": "#F4F4F4"
+      "borderColor": "#FAFAFA"
     },
     "NewClass": {
       "Panel": {
-        "background": "#F4F4F4"
+        "background": "#FAFAFA"
       },
       "SearchField": {
-        "background": "#F4F4F4"
+        "background": "#FAFAFA"
       }
     },
     "NewPSD.warning": "#2979ff",
@@ -414,7 +414,7 @@
     },
     "OnePixelDivider.background": "#DBDBDC",
     "OptionPane": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "foreground": "#232324",
       "messageForeground": "#232324"
     },
@@ -424,7 +424,7 @@
       "disabledColor": "#b8b8b9"
     },
     "Panel": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "foreground": "#232324"
     },
     "ParameterInfo": {
@@ -438,7 +438,7 @@
       "lineSeparatorColor": "#DBDBDC"
     },
     "PasswordField": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "capsLockIconColor": "#2979ff",
       "caretForeground": "#2979ff",
       "foreground": "#232324",
@@ -447,13 +447,13 @@
       "selectionForeground": "#232324"
     },
     "Plugins": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "disabledForeground": "#b8b8b9",
       "eapTagBackground": "#FFFFFF",
       "hoverBackground": "#DBDBDC80",
       "lightSelectionBackground": "#DBDBDC",
       "paidTagBackground": "#FFFFFF",
-      "selectionBackground": "#FFFFFF",
+      "selectionBackground": "#2979ff80",
       "tagForeground": "#2979ff",
       "tagBackground": "#FFFFFF",
       "trialTagBackground": "#FFFFFF",
@@ -469,7 +469,7 @@
         "updateForeground": "#232324"
       },
       "SearchField": {
-        "background": "#F4F4F4",
+        "background": "#FAFAFA",
         "borderColor": "#DBDBDC"
       },
       "SectionHeader": {
@@ -484,36 +484,36 @@
     },
     "Popup": {
       "Advertiser": {
-        "background": "#F4F4F4",
-        "borderColor": "#F4F4F4",
+        "background": "#FAFAFA",
+        "borderColor": "#FAFAFA",
         "foreground": "#2979ff"
       },
-      "borderColor": "#eaeae",
-      "inactiveBorderColor": "#F4F4F4",
+      "borderColor": "#EAEAEA",
+      "inactiveBorderColor": "#FAFAFA",
       "innerBorderColor": "#EAEAEB",
       "Header": {
-        "activeBackground": "#F4F4F4",
-        "inactiveBackground": "#eaeae"
+        "activeBackground": "#FAFAFA",
+        "inactiveBackground": "#EAEAEA"
       },
       "paintBorder": true,
       "separatorForeground": "#232324",
       "separatorColor": "#EAEAEB",
       "Toolbar": {
-        "Floating.background": "#eaeae",
-        "background": "#eaeae",
-        "borderColor": "#eaeae"
+        "Floating.background": "#EAEAEA",
+        "background": "#EAEAEA",
+        "borderColor": "#EAEAEA"
       }
     },
     "PopupMenu": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "border": "2,0,2,0",
       "foreground": "#232324",
-      "translucentBackground": "#F4F4F4"
+      "translucentBackground": "#FAFAFA"
     },
     "PopupMenuSeparator.height": 10,
     "PopupMenuSeparator.stripeIndent": 5,
     "ProgressBar": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "foreground": "#2979ff",
       "indeterminateEndColor": "#2979ff",
       "indeterminateStartColor": "#2979ff",
@@ -525,70 +525,70 @@
       "referenceHighlightColor": "#2979ff"
     },
     "RadioButton": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "disabledText": "#b8b8b9",
       "foreground": "#232324"
     },
     "RadioButtonMenuItem": {
       "acceleratorForeground": "#7f7f7f",
       "acceleratorSelectionForeground": "#7f7f7f",
-      "background": "#F4F4F4",
-      "disabledBackground": "#F4F4F4",
+      "background": "#FAFAFA",
+      "disabledBackground": "#FAFAFA",
       "disabledForeground": "#b8b8b9",
       "foreground": "#232324",
-      "selectionBackground": "#FFFFFF",
+      "selectionBackground": "#2979ff80",
       "selectionForeground": "#232324"
     },
     "ScreenView.borderColor": "#DBDBDC",
     "ScrollBar": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "hoverThumbBorderColor": "#2979ff",
       "hoverThumbColor": "#2979ff",
-      "hoverTrackColor": "#F4F4F430",
+      "hoverTrackColor": "#FAFAFA30",
       "Mac": {
         "hoverThumbBorderColor": "#2979ff",
         "hoverThumbColor": "#2979ff",
-        "hoverTrackColor": "#F4F4F430",
+        "hoverTrackColor": "#FAFAFA30",
         "thumbBorderColor": "#2979ff70",
         "thumbColor": "#2979ff70",
-        "trackColor": "#F4F4F430",
+        "trackColor": "#FAFAFA30",
         "Transparent": {
           "hoverThumbBorderColor": "#2979ff",
           "hoverThumbColor": "#2979ff",
-          "hoverTrackColor": "#F4F4F430",
+          "hoverTrackColor": "#FAFAFA30",
           "thumbBorderColor": "#2979ff70",
           "thumbColor": "#2979ff70",
-          "trackColor": "#F4F4F430"
+          "trackColor": "#FAFAFA30"
         }
       },
       "thumb": "#FFFFFF",
       "thumbBorderColor": "#2979ff70",
       "thumbColor": "#2979ff70",
-      "trackColor": "#F4F4F430",
+      "trackColor": "#FAFAFA30",
       "Transparent": {
         "hoverThumbBorderColor": "#2979ff",
         "hoverThumbColor": "#2979ff",
-        "hoverTrackColor": "#F4F4F430",
+        "hoverTrackColor": "#FAFAFA30",
         "thumbBorderColor": "#2979ff70",
         "thumbColor": "#2979ff70",
-        "trackColor": "#F4F4F430"
+        "trackColor": "#FAFAFA30"
       }
     },
     "SearchEverywhere": {
       "Advertiser": {
-        "background": "#eaeae",
+        "background": "#EAEAEA",
         "foreground": "#7f7f7f"
       },
       "Header": {
-        "background": "#F4F4F4"
+        "background": "#FAFAFA"
       },
       "List": {
         "separatorForeground": "#7f7f7f",
         "separatorColor": "#DBDBDC"
       },
       "SearchField": {
-        "background": "#F4F4F4",
-        "borderColor": "#eaeae",
+        "background": "#FAFAFA",
+        "borderColor": "#EAEAEA",
         "infoForeground": "#7f7f7f"
       },
       "Tab": {
@@ -617,10 +617,10 @@
       "separatorColor": "#EAEAEB"
     },
     "SidePanel": {
-      "background": "#F4F4F4"
+      "background": "#FAFAFA"
     },
     "Slider": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "buttonBorderColor": "#2979ff",
       "buttonColor": "#2979ff",
       "foreground": "#232324",
@@ -637,23 +637,23 @@
       "errorForeground": "#232324"
     },
     "Spinner": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "border": "3,3,3,3",
       "foreground": "#232324",
       "selectionForeground": "#232324"
     },
     "SplitPane": {
-      "background": "#F4F4F4",
-      "highlight": "#F4F4F4"
+      "background": "#FAFAFA",
+      "highlight": "#FAFAFA"
     },
     "SplitPaneDivider.draggingColor": "#EAEAEB",
     "StatusBar": {
-      "borderColor": "#F4F4F4",
+      "borderColor": "#FAFAFA",
       "hoverBackground": "#FFFFFF",
       "LightEditBackground": "#DBDBDC"
     },
     "TabbedPane": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "contentAreaColor": "#FFFFFF",
       "contentBorderInsets": "3,1,1,1",
       "darkShadow": "#DBDBDC",
@@ -675,10 +675,10 @@
       "tabSelectionHeight": 2,
       "underlineColor": "#2979ff"
     },
-    "TabbedPane.mt.tab.background": "#F4F4F4",
+    "TabbedPane.mt.tab.background": "#FAFAFA",
     "Table": {
-      "alternativeRowBackground": "#eaeae",
-      "background": "#F4F4F4",
+      "alternativeRowBackground": "#EAEAEA",
+      "background": "#FAFAFA",
       "cellNoFocusBorder": "10,5,10,5",
       "focusCellHighlightBorder": "10,5,10,5",
       "disabledForeground": "#b8b8b9",
@@ -687,7 +687,7 @@
       "focusCellBackground": "#DBDBDC",
       "focusCellForeground": "#232324",
       "foreground": "#232324",
-      "gridColor": "#F4F4F4",
+      "gridColor": "#FAFAFA",
       "highlightOuter": "#DBDBDC",
       "hoverBackground": "#DBDBDC80",
       "hoverInactiveBackground": "#DBDBDC",
@@ -699,11 +699,11 @@
       "selectionInactiveBackground": "#DBDBDC",
       "selectionInactiveForeground": "#232324",
       "sortIconColor": "#232324",
-      "stripeColor": "#eaeae"
+      "stripeColor": "#EAEAEA"
     },
     "TableHeader": {
-      "background": "#F4F4F4",
-      "borderColor": "#F4F4F4",
+      "background": "#FAFAFA",
+      "borderColor": "#FAFAFA",
       "bottomSeparatorColor": "#EAEAEB",
       "cellBorder": "4,0,4,0",
       "disabledForeground": "#b8b8b9",
@@ -717,7 +717,7 @@
     "textInactiveText": "#7f7f7f",
     "textText": "#7f7f7f",
     "TextArea": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "caretForeground": "#2979ff",
       "foreground": "#232324",
       "inactiveForeground": "#b8b8b9",
@@ -725,7 +725,7 @@
       "selectionForeground": "#232324"
     },
     "TextField": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "caretForeground": "#2979ff",
       "foreground": "#232324",
       "inactiveForeground": "#b8b8b9",
@@ -733,7 +733,7 @@
       "selectionForeground": "#232324"
     },
     "TextPane": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "caretForeground": "#2979ff",
       "foreground": "#232324",
       "inactiveForeground": "#b8b8b9",
@@ -741,9 +741,9 @@
       "selectionForeground": "#232324"
     },
     "TitlePane": {
-      "background": "#eaeae",
+      "background": "#EAEAEA",
       "Button.hoverBackground": "#FFFFFF",
-      "inactiveBackground": "#F4F4F4",
+      "inactiveBackground": "#FAFAFA",
       "infoForeground": "#7f7f7f",
       "inactiveInfoForeground": "#7f7f7f"
     },
@@ -753,19 +753,19 @@
       "buttonColor": "#232324",
       "disabledText": "#b8b8b9",
       "foreground": "#232324",
-      "offForeground": "#F4F4F4",
-      "offBackground": "#F4F4F4",
+      "offForeground": "#FAFAFA",
+      "offBackground": "#FAFAFA",
       "onBackground": "#2979ff",
       "onForeground": "#2979ff"
     },
     "ToolBar": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "borderHandleColor": "#7f7f7f",
       "floatingForeground": "#7f7f7f",
       "foreground": "#232324"
     },
     "ToolTip": {
-      "Actions.background": "#F4F4F4",
+      "Actions.background": "#FAFAFA",
       "Actions.infoForeground": "#7f7f7f",
       "background": "#F2F2F2",
       "borderColor": "#DBDBDC",
@@ -778,23 +778,23 @@
       "Button": {
         "hoverBackground": "#DBDBDC",
         "selectedForeground": "#232324",
-        "selectedBackground": "#eaeae"
+        "selectedBackground": "#EAEAEA"
       },
       "Header": {
-        "background": "#F4F4F4",
+        "background": "#FAFAFA",
         "borderColor": "#EAEAEB",
-        "inactiveBackground": "#F4F4F4"
+        "inactiveBackground": "#FAFAFA"
       },
       "HeaderCloseButton": {
-        "background": "#F4F4F4"
+        "background": "#FAFAFA"
       },
       "HeaderTab": {
         "borderColor": "#FFFFFF",
         "hoverBackground": "#FFFFFF",
         "hoverInactiveBackground": "#FFFFFF",
         "inactiveUnderlineColor": "#2979ff",
-        "selectedBackground": "#eaeae",
-        "selectedInactiveBackground": "#eaeae",
+        "selectedBackground": "#EAEAEA",
+        "selectedInactiveBackground": "#EAEAEA",
         "underlineColor": "#2979ff",
         "underlinedTabBackground": "#DBDBDC",
         "underlinedTabInactiveBackground": "#EAEAEB",
@@ -803,7 +803,7 @@
       }
     },
     "Tree": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "foreground": "#7f7f7f",
       "hash": "#DBDBDC",
       "hoverBackground": "#DBDBDC80",
@@ -814,20 +814,20 @@
       "selectionForeground": "#232324",
       "selectionInactiveForeground": "#232324",
       "selectionInactiveBackground": "#DBDBDC80",
-      "textBackground": "#F4F4F4"
+      "textBackground": "#FAFAFA"
     },
     "Tree.leftChildIndent": 10,
     "Tree.rightChildIndent": 5,
     "UIDesigner": {
       "Activity.borderColor": "#DBDBDC",
-      "Canvas.background": "#eaeae",
+      "Canvas.background": "#EAEAEA",
       "ColorPicker": {
-        "background": "#F4F4F4",
+        "background": "#FAFAFA",
         "foreground": "#232324"
       },
       "Component": {
         "borderColor": "#DBDBDC",
-        "background": "#F4F4F4",
+        "background": "#FAFAFA",
         "foreground": "#232324",
         "hoverBorderColor": "#FFFFFF"
       },
@@ -835,7 +835,7 @@
         "borderColor": "#DBDBDC",
         "hoverBorderColor": "#FFFFFF"
       },
-      "Canvas.background": "#eaeae",
+      "Canvas.background": "#EAEAEA",
       "highStroke.foreground": "#232324",
       "Label.foreground": "#7f7f7f",
       "List.selectionBackground": "#DBDBDC80",
@@ -844,12 +844,12 @@
         "Component.foreground": "#232324",
         "ConstraintSetText.foreground": "#7f7f7f",
         "ConstraintSet.background": "#EAEAEB",
-        "CSPanel.SelectedFocusBackground": "#FFFFFF",
+        "CSPanel.SelectedFocusBackground": "#2979ff80",
         "CSPanel.SelectedBackground": "#DBDBDC80",
         "cs_FocusText.infoForeground": "#7f7f7f",
         "CursorTextColor.foreground": "#232324",
         "HoverColor.disabledBackground": "#b8b8b9",
-        "motionGraph.background": "#F4F4F4",
+        "motionGraph.background": "#FAFAFA",
         "Notification.background": "#F2F2F2",
         "ourAvg.background": "#EAEAEB",
         "ourCS.background": "#EAEAEB",
@@ -859,24 +859,24 @@
         "ourCS_SelectedBackground.selectionInactiveBackground": "#DBDBDC",
         "ourCS_SelectedBorder.pressedBorderColor": "#FFFFFF",
         "ourML_BarColor.separatorColor": "#DBDBDC",
-        "PrimaryPanel.background": "#eaeae",
-        "SecondaryPanel.background": "#F4F4F4",
+        "PrimaryPanel.background": "#EAEAEA",
+        "SecondaryPanel.background": "#FAFAFA",
         "SecondaryPanel.header.foreground": "#7f7f7f",
-        "SecondaryPanel.header.background": "#eaeae",
+        "SecondaryPanel.header.background": "#EAEAEA",
         "timeLine.disabledBorderColor": "#DBDBDC"
       },
       "Panel": {
         "borderColor": "#DBDBDC",
-        "background": "#F4F4F4"
+        "background": "#FAFAFA"
       },
       "percent.foreground": "#232324",
       "Placeholder": {
-        "background": "#F4F4F4",
+        "background": "#FAFAFA",
         "borderColor": "#DBDBDC",
         "foreground": "#232324",
         "selectedForeground": "#232324"
       },
-      "Preview.background": "#F4F4F4",
+      "Preview.background": "#FAFAFA",
       "stroke.acceleratorForeground": "#7f7f7f"
     },
     "ValidationTooltip": {
@@ -887,7 +887,7 @@
     },
     "VersionControl": {
       "FileHistory.Commit": {
-        "selectedBranchBackground": "#F4F4F4"
+        "selectedBranchBackground": "#FAFAFA"
       },
       "GitCommits": {
         "graphColor": "#FFFFFF"
@@ -918,44 +918,44 @@
       }
     },
     "Viewport": {
-      "background": "#F4F4F4",
+      "background": "#FAFAFA",
       "foreground": "#232324"
     },
     "WelcomeScreen": {
-      "AssociatedComponent.background": "#F4F4F4",
-      "background": "#F4F4F4",
-      "borderColor": "#F4F4F4",
-      "captionBackground": "#eaeae",
+      "AssociatedComponent.background": "#FAFAFA",
+      "background": "#FAFAFA",
+      "borderColor": "#FAFAFA",
+      "captionBackground": "#EAEAEA",
       "captionForeground": "#232324",
-      "Details.background": "#F4F4F4",
-      "footerBackground": "#eaeae",
+      "Details.background": "#FAFAFA",
+      "footerBackground": "#EAEAEA",
       "footerForeground": "#232324",
-      "headerBackground": "#F4F4F4",
+      "headerBackground": "#FAFAFA",
       "headerForeground": "#232324",
-      "List.background": "#eaeae",
+      "List.background": "#EAEAEA",
       "separatorColor": "#DBDBDC",
       "SidePanel.background": "#EAEAEB",
       "Projects": {
-        "actions.background": "#eaeae",
+        "actions.background": "#EAEAEA",
         "actions.selectionBackground": "#FFFFFF",
         "background": "#EAEAEB",
-        "selectionBackground": "#FFFFFF",
+        "selectionBackground": "#2979ff80",
         "selectionInactiveBackground": "#EAEAEB"
       }
     },
-    "window": "#F4F4F4",
+    "window": "#FAFAFA",
     "windowBorder": "#DBDBDC",
     "windowText": "#7f7f7f",
     "Window.border": "#DBDBDC"
   },
   "icons": {
     "ColorPalette": {
-      "#43494A": "#eaeae",
+      "#43494A": "#EAEAEA",
       "#6B6B6B": "#7f7f7f",
-      "#A7A7A7": "#F4F4F4",
+      "#A7A7A7": "#FAFAFA",
       "#3D6185": "#2979ff",
       "#466D94": "#2979ff",
-      "#3C3F41": "#F4F4F4",
+      "#3C3F41": "#FAFAFA",
       "#545556": "#b8b8b9",
       "#606060": "#b8b8b9",
       "#9AA7B0": "#232324",
@@ -967,8 +967,8 @@
       "Actions.GreyInline.Dark": "#232324",
       "Actions.Red": "#E4564A",
       "Actions.Yellow": "#C18401",
-      "Checkbox.Background.Default": "#eaeae",
-      "Checkbox.Background.Default.Dark": "#eaeae",
+      "Checkbox.Background.Default": "#EAEAEA",
+      "Checkbox.Background.Default.Dark": "#EAEAEA",
       "Checkbox.Background.Disabled": "#CACACB",
       "Checkbox.Background.Disabled.Dark": "#CACACB",
       "Checkbox.Border.Default": "#DBDBDC",
@@ -982,7 +982,7 @@
       "Checkbox.Foreground.Disabled": "#b8b8b9",
       "Checkbox.Foreground.Disabled.Dark": "#b8b8b9",
       "Checkbox.Background.Selected": "#2979ff",
-      "Checkbox.Background.Selected.Dark": "#F4F4F4",
+      "Checkbox.Background.Selected.Dark": "#FAFAFA",
       "Checkbox.Border.Selected": "#2979ff",
       "Checkbox.Border.Selected.Dark": "#2979ff",
       "Checkbox.Foreground.Selected": "#2979ff",


### PR DESCRIPTION
Hey! 

I saw some issues regarding the Atom One Light theme while using it. It did show the wrong name and did not use the contrast color. Thus, i took a look at your repo and found the fixes i guess.
Furthermore, i changed some colors for on the one hand readability (selectBg) and on the other hand consistency (background). 

I also got a Question regarding file colors. I saw that we provide colors in the themes.yml for _green_, _blue_ etc. for each theme but do not use them. I'd propose to use them for coloring the files in the template.theme.json:

```   
 "FileColor": {
      "Green": "#387002",
      "Blue": "#004BA0",
      "Yellow": "%excl",
      "Orange": "#B53D00",
      "Violet": "#4D2C91",
      "Rose": "#A00037"
    },
```   

For example the green color of the files is too dark for the One Light theme. The colors provided by each style in the themes.yml would be reasonable i guess. I'd then of course love to contribute another PR. 🔥  

Looking forward for feedback and suggestions. 😄 
